### PR TITLE
Fix audio not playing on mobile

### DIFF
--- a/src/Components/AudioPlayer/index.js
+++ b/src/Components/AudioPlayer/index.js
@@ -1,28 +1,30 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { AudioPlayerContainer } from './index.style';
 import AudioSpinner from '../AudioSpinner/index';
 import audioFile from '../../Audio/verySpecialAudioFile.mp3';
 
 const AudioPlayer = ({ volume }) => {
-  const [playing, setPlaying] = useState(false);
-  const audio = useRef(new Audio(audioFile));
+  const [playing, setPlaying] = React.useState(false);
+  const audio = React.useRef(new Audio(audioFile));
 
-  useEffect(() => {
-    if (playing) {
-      audio.current.play();
-    } else {
-      audio.current.pause();
-    }
-  }, [playing]);
-
-  useEffect(() => {
+  React.useEffect(() => {
+    // On iOS devices, the audio level is always under the user's
+    // physical control. The volume property is not settable in
+    // JavaScript. Reading the volume property always returns 1.
+    // Source: https://apple.co/2Yk5IEK
     audio.current.volume = volume / 100;
-  }, [volume, playing]);
+  }, [audio, volume]);
 
   return (
     <AudioPlayerContainer>
-      <AudioSpinner playing={playing} setPlaying={setPlaying} />
+      <AudioSpinner
+        playing={playing}
+        onClick={() => {
+          playing ? audio.current.pause() : audio.current.play();
+          setPlaying(!playing);
+        }}
+      />
     </AudioPlayerContainer>
   );
 };

--- a/src/Components/AudioSpinner/index.js
+++ b/src/Components/AudioSpinner/index.js
@@ -1,17 +1,13 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { AudioSpinnerContainer } from './index.style';
 
-const AudioSpinner = ({ playing, setPlaying }) => {
-  const switchPlaying = useCallback(() => {
-    setPlaying(!playing);
-  }, [setPlaying, playing]);
-
+const AudioSpinner = ({ playing, onClick }) => {
   return (
     <AudioSpinnerContainer>
       <i
         className={`fas fa-play-circle${playing ? ' rotate' : ''}`}
-        onClick={switchPlaying}
+        onClick={onClick}
       />
     </AudioSpinnerContainer>
   );
@@ -19,7 +15,7 @@ const AudioSpinner = ({ playing, setPlaying }) => {
 
 AudioSpinner.propTypes = {
   playing: PropTypes.bool,
-  setPlaying: PropTypes.func,
+  onClick: PropTypes.func,
 };
 
 export default AudioSpinner;


### PR DESCRIPTION
The main problem in issue #8 was fixed, but the volume still can't be modified on iPhone - Safari _(see comments for details)_. This will be a new issue until a fix is fond, but the audio is still playable and the sliders are usable _(although they do nothing)_ on all mobile devices. 